### PR TITLE
Use unpkg.com and update MapTile access token

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -17,8 +17,8 @@
     <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"></script>
 
     <!-- Maplibre GL -->
-    <link href="https://media.seventhsense.ai/maplibre-gl-js/v1.14.0/maplibre-gl.css" rel='stylesheet' />
-    <script src="https://media.seventhsense.ai/maplibre-gl-js/v1.14.0/maplibre-gl.js"></script>
+    <link href="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.css" rel='stylesheet' />
+    <script src="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.js"></script>
 
 </head>
 
@@ -36,7 +36,7 @@ L.marker([38.912753, -77.032194])
 
 var gl = L.maplibreGL({
     // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style
-    style: 'https://api.maptiler.com/maps/topo/style.json?key=gbetYLSD5vR8MdtZ88AQ'
+    style: 'https://api.maptiler.com/maps/topo/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
 }).addTo(map);
 
 </script>

--- a/examples/cluster.html
+++ b/examples/cluster.html
@@ -10,8 +10,8 @@
     <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"></script>
 
     <!-- Maplibre GL -->
-    <link href="https://media.seventhsense.ai/maplibre-gl-js/v1.14.0/maplibre-gl.css" rel='stylesheet' />
-    <script src="https://media.seventhsense.ai/maplibre-gl-js/v1.14.0/maplibre-gl.js"></script>
+    <link href="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.css" rel='stylesheet' />
+    <script src="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.js"></script>
 
     <!-- Leaflet.MarkerCluster -->
     <script src='https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.0.4/leaflet.markercluster.js'></script>
@@ -32,7 +32,7 @@ var map = L.map('map', {maxZoom: 17}).setView([-37.821, 175.219], 16);
 
 var gl = L.maplibreGL({
     // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style
-    style: 'https://api.maptiler.com/maps/basic/style.json?key=gbetYLSD5vR8MdtZ88AQ'
+    style: 'https://api.maptiler.com/maps/basic/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
 }).addTo(map);
 
 var markers = L.markerClusterGroup();

--- a/examples/events.html
+++ b/examples/events.html
@@ -17,8 +17,8 @@
     <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"></script>
 
     <!-- Maplibre GL -->
-    <link href="https://media.seventhsense.ai/maplibre-gl-js/v1.14.0/maplibre-gl.css" rel='stylesheet' />
-    <script src="https://media.seventhsense.ai/maplibre-gl-js/v1.14.0/maplibre-gl.js"></script>
+    <link href="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.css" rel='stylesheet' />
+    <script src="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.js"></script>
   </head>
   <body>
   <div id="map"></div>
@@ -34,7 +34,7 @@
   var gl = L.maplibreGL({
     padding: 0.1,
     // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style
-    style: 'https://api.maptiler.com/maps/basic/style.json?key=gbetYLSD5vR8MdtZ88AQ',
+    style: 'https://api.maptiler.com/maps/basic/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
     interactive: true
   }).addTo(leafletMap);
 

--- a/examples/overlay.html
+++ b/examples/overlay.html
@@ -7,8 +7,8 @@
   <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"></script>
 
   <!-- Maplibre GL -->
-  <link href="https://media.seventhsense.ai/maplibre-gl-js/v1.14.0/maplibre-gl.css" rel='stylesheet' />
-  <script src="https://media.seventhsense.ai/maplibre-gl-js/v1.14.0/maplibre-gl.js"></script>
+  <link href="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.css" rel='stylesheet' />
+  <script src="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.js"></script>
   <script src="../leaflet-maplibre-gl.js"></script>
   <style>
     html, body, #map {
@@ -26,7 +26,7 @@
     var map = new L.Map('map');
 		var gl = L.maplibreGL({
       // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style
-      style: 'https://api.maptiler.com/maps/basic/style.json?key=gbetYLSD5vR8MdtZ88AQ'
+      style: 'https://api.maptiler.com/maps/basic/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
     }).addTo(map);
 
 		var	bounds = new L.LatLngBounds(


### PR DESCRIPTION
This pull request makes the examples use unpkg.com as the content delivery network for `maplibre-gl.js`. 

It updates the MapTiler access token to `get_your_own_OpIi9ZULNHzrESv6T2vL`, which is token provided by Petr Pridal (@klokan) for the [documentation of maplibre-gl-js](https://maplibre.org/maplibre-gl-js-docs/api/).