### PR TITLE
Add publish workflow, bump version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: publish
+
+on:
+  workflow_dispatch
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js 10 x64
+        uses: actions/setup-node@v2
+        with:
+          node-version: 10
+          architecture: x64
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish
+        run: |
+          npm publish --access=public --non-interactive --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,9 @@ name: publish
 
 on:
   workflow_dispatch
+  push:
+    tags:
+      - v*
 
 jobs:
   publish:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "maplibre-gl-leaflet",
+  "name": "@maplibre/maplibre-gl-leaflet",
   "version": "0.0.14-rc.1",
   "description": "binding from maplibre gl to the leaflet api",
   "main": "leaflet-maplibre-gl.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-leaflet",
-  "version": "0.0.14",
+  "version": "0.0.14-rc.1",
   "description": "binding from maplibre gl to the leaflet api",
   "main": "leaflet-maplibre-gl.js",
   "directories": {


### PR DESCRIPTION
This pull request adds the `publish.yml` github action workflow which publishes `maplibre-gl-leaflet` to NPM on manual trigger.

`secrets.NODE_AUTH_TOKEN` stores a npmjs.com access token that is associated with my account (https://www.npmjs.com/~wipfli). @nyurik please add me to the maplibre organization.