### PR TITLE
Add types definition

### DIFF
--- a/API.md
+++ b/API.md
@@ -37,3 +37,7 @@ Returns layer size in pixels including padding.
 ### `layer.getBounds(): L.LatLngBounds`
 
 Returns layer bounds including padding.
+
+### `layer.getPaneName(): string`
+
+Returns the pane name set in options if it is a valid pane, defaults to tilePane.

--- a/leaflet-maplibre-gl.d.ts
+++ b/leaflet-maplibre-gl.d.ts
@@ -1,0 +1,17 @@
+import * as L from 'leaflet';
+import { Map, MapboxOptions } from 'maplibre-gl';
+
+declare module 'leaflet' {
+    class MaplibreGL extends L.Layer {
+        constructor(options: MapboxOptions);
+        getMaplibreMap(): Map
+        getCanvas(): HTMLCanvasElement
+        getSize(): L.Point
+        getBounds(): L.LatLngBounds
+        getContainer(): HTMLDivElement
+        getPaneName(): string
+    }
+
+    function maplibreGL(options: MapboxOptions): MaplibreGL;
+
+}

--- a/package.json
+++ b/package.json
@@ -33,5 +33,6 @@
   "peerDependencies": {
     "leaflet": "^1.0.0",
     "maplibre-gl": "^1.14.0"
-  }
+  },
+  "types": "leaflet-maplibre-gl.d.ts"
 }


### PR DESCRIPTION
Added types definitions file which will improve developer experience when importing/using this package in a Typescript environment.

The typings for `mapbox-gl-leaflet` was provided as a separate `@types/mapbox-gl-leaflet` package... (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mapbox-gl-leaflet/index.d.ts)