### PR TITLE
Update CHANGELOG.md and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## Unreleased
 
-## [0.0.14] - 2020-11-24
+## 0.0.15 - 2021-07-08
+
+### Added
+- types definition
+
+## 0.0.14 - 2020-11-24
 
 ### Fixed
 
 - fix gl offset issue in low zoom level
 
-## [0.0.13] - 2020-08-31
+## 0.0.13 - 2020-08-31
 
 ### Added
 -  `.getPaneName()` method
@@ -20,19 +25,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Allow gl tiles to be added to a custom pane defined in options
 
-## [0.0.12] - 2020-03-27
+## 0.0.12 - 2020-03-27
 
 ### Fixed
 
 - `accessToken` is now optional
 
-## [0.0.11] - 2019-11-04
+## 0.0.11 - 2019-11-04
 
 ### Fixed
 
 - ensure gl map is added to leaflet TilePane
 
-## [0.0.10] - 2019-09-16
+## 0.0.10 - 2019-09-16
 
 ## Added
 
@@ -42,39 +47,39 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - internal code changes to bring it closer to other overlay layers.
 
-## [0.0.9] - 2019-09-02
+## 0.0.9 - 2019-09-02
 
 ## Added
 
 - Added `interactive` option to make `mapbox-gl` map events handling possible.
 - added public accessor to `mapbox-gl` map object
 
-## [0.0.8] - 2019-08-07
+## 0.0.8 - 2019-08-07
 
 ## Added
 
 - Added a `padding` option to fix the grey backgrougd flickering around the edges of the map while panning/zooming
 - bumped the libraries in examples
 
-## [0.0.7] - 2019-07-01
+## 0.0.7 - 2019-07-01
 
 ### Fixed
 
 - Ensure no blank/gray area is displayed when zooming out.
 
-## [0.0.6] - 2019-05-07
+## 0.0.6 - 2019-05-07
 
 ### Fixed
 
 - `.git` directory removed from npm tarball.
 
-## [0.0.5] - 2019-05-01
+## 0.0.5 - 2019-05-01
 
 ### Added
 
 - `leaflet` and `mapbox-gl-js` are now declared as peerDependencies.
 
-## [0.0.4] - 2019-02-27
+## 0.0.4 - 2019-02-27
 
 ### Added
 
@@ -85,13 +90,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - webkitTransitionEnd event crash
 
-## [0.0.3] - 2017-04-18
+## 0.0.3 - 2017-04-18
 
 ### Added
 
 - Improved support for older versions of `mapbox-gl-js`
 
-## [0.0.2] - 2017-03-08
+## 0.0.2 - 2017-03-08
 
 ### Added
 
@@ -100,18 +105,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 0.7. - 2016-10-09
 
 - Compatibility release for Leaflet `v0.7.x`
-
-[Unreleased]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.14...HEAD
-[0.0.14]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.13...v0.0.13
-[0.0.13]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.12...v0.0.13
-[0.0.12]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.11...v0.0.12
-[0.0.11]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.10...v0.0.11
-[0.0.10]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.9...v0.0.10
-[0.0.9]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.8...v0.0.9
-[0.0.8]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.7...v0.0.8
-[0.0.7]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.6...v0.0.7
-[0.0.6]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.5...v0.0.6
-[0.0.5]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.4...v0.0.5
-[0.0.4]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.3...v0.0.4
-[0.0.3]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.0.2...v0.0.3
-[0.0.2]: https://github.com/codespree/maplibre-gl-leaflet/compare/v0.7...v0.0.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-leaflet",
-  "version": "0.0.14-rc.1",
+  "version": "0.0.15-rc.1",
   "description": "binding from maplibre gl to the leaflet api",
   "main": "leaflet-maplibre-gl.js",
   "directories": {


### PR DESCRIPTION
This pull request mentions the newly added type definitions #14, removes links in CHANGELOG.md that point nowhere, and increases the version to release candidate `v0.0.15-rc.1`.