### PR TITLE
Use organization secret NPM_ORG_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,4 +24,4 @@ jobs:
         run: |
           npm publish --access=public --non-interactive
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}


### PR DESCRIPTION
Please read https://github.com/maplibre/maplibre-gl-js/pull/231. @nyurik please share the MapLibre organization secret `NPM_ORG_TOKEN` with this repo.