### PR TITLE
Fix type definitions

### DIFF
--- a/API.md
+++ b/API.md
@@ -37,3 +37,7 @@ Returns layer size in pixels including padding.
 ### `layer.getBounds(): L.LatLngBounds`
 
 Returns layer bounds including padding.
+
+### `layer.getPaneName(): string`
+
+Returns the pane name set in options if it is a valid pane, defaults to tilePane.

--- a/leaflet-maplibre-gl.d.ts
+++ b/leaflet-maplibre-gl.d.ts
@@ -1,0 +1,17 @@
+import * as L from 'leaflet';
+import { Map, MapboxOptions } from 'maplibre-gl';
+
+declare module 'leaflet' {
+    class MaplibreGL extends L.Layer {
+        constructor(options: MapboxOptions);
+        getMaplibreMap(): Map
+        getCanvas(): HTMLCanvasElement
+        getSize(): L.Point
+        getBounds(): L.LatLngBounds
+        getContainer(): HTMLDivElement
+        getPaneName(): string
+    }
+
+    function maplibreGL(options: MapboxOptions): MaplibreGL;
+
+}

--- a/leaflet-maplibre-gl.d.ts
+++ b/leaflet-maplibre-gl.d.ts
@@ -1,9 +1,12 @@
 import * as L from 'leaflet';
 import { Map, MapboxOptions } from 'maplibre-gl';
 
+
 declare module 'leaflet' {
+    type LeafletMaplibreGLOptions = Omit<MapboxOptions, "container">;
+
     class MaplibreGL extends L.Layer {
-        constructor(options: MapboxOptions);
+        constructor(options: LeafletMaplibreGLOptions);
         getMaplibreMap(): Map
         getCanvas(): HTMLCanvasElement
         getSize(): L.Point
@@ -12,6 +15,6 @@ declare module 'leaflet' {
         getPaneName(): string
     }
 
-    function maplibreGL(options: MapboxOptions): MaplibreGL;
+    function maplibreGL(options: LeafletMaplibreGLOptions): MaplibreGL;
 
 }

--- a/package.json
+++ b/package.json
@@ -33,5 +33,6 @@
   "peerDependencies": {
     "leaflet": "^1.0.0",
     "maplibre-gl": "^1.14.0"
-  }
+  },
+  "types": "leaflet-maplibre-gl.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "leafletjs",
     "maps"
   ],
-  "files": [],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/maplibre/maplibre-gl-leaflet/issues"


### PR DESCRIPTION
- Fixed `package.json` so definition files is not being ignored during npm publish.
- Fix to the type definition so property `container` is not required when passing options to the leaflet plugin