### PR TITLE
Support dynamic imports in UMD wrapper

### DIFF
--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -7,10 +7,9 @@
         module.exports = factory(require('leaflet'), require('maplibre-gl'));
     } else {
         // Browser globals (root is window)
-        root = typeof globalThis !== 'undefined' ? globalThis : root || self;
         root.returnExports = factory(root.L, root.maplibregl);
     }
-}(this, function (L, maplibregl) {
+}(typeof globalThis !== 'undefined' ? globalThis : this || self, function (L, maplibregl) {
     L.MaplibreGL = L.Layer.extend({
             options: {
             updateInterval: 32,

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -8,7 +8,7 @@
     } else {
         // Browser globals (root is window)
         root = typeof globalThis !== 'undefined' ? globalThis : root || self;
-        root.returnExports = factory(window.L, window.maplibregl);
+        root.returnExports = factory(root.L, root.maplibregl);
     }
 }(this, function (L, maplibregl) {
     L.MaplibreGL = L.Layer.extend({

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -7,6 +7,7 @@
         module.exports = factory(require('leaflet'), require('maplibre-gl'));
     } else {
         // Browser globals (root is window)
+        root = typeof globalThis !== 'undefined' ? globalThis : root || self;
         root.returnExports = factory(window.L, window.maplibregl);
     }
 }(this, function (L, maplibregl) {


### PR DESCRIPTION
Loading leaflet-maplibre-gl.js with [Dynamic Imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports) raises an error:

`TypeError: root is undefined` in [leaflet-maplibre-gl.js:10](https://github.com/maplibre/maplibre-gl-leaflet/blob/46168f6da1d680fe633c1b408b6796e7598319a9/leaflet-maplibre-gl.js#L10)

See [minimal example](https://plnkr.co/edit/cYcix0fUJp7rzIeY?open=lib%2Fscript.js&preview) to reproduce (output in console log), basically this line:
```js
import('https://unpkg.com/@maplibre/maplibre-gl-leaflet@0.0.16/leaflet-maplibre-gl.js')
  .then(() => console.log('L.maplibreGL: ', L.maplibreGL))
```
The error occurs because `this` is `undefined`, as the `import()` call loads as module in strict mode (but can be called from a regular script).

Importing [maplibre-gl.js](https://unpkg.com/browse/maplibre-gl@2.1.9/dist/maplibre-gl.js) works, the UMD wrapper there is generated by Rollup.

Detecting `self` (and/or `globalThis`) in addition to `this` helps, examples:
- [rollup umd.ts](https://github.com/rollup/rollup/blob/b74cb92e84f33ac140ae2b1ddb65d55a6dbb6ae6/src/finalisers/umd.ts#L158), [example output](https://github.com/rollup/rollup/blob/0ab16cc04b7d6dfe5bd14340ba7448085a379e25/test/form/samples/globals-function/_expected/umd.js#L4):
  - `(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.thisIsA, global.thisIsB));`
- [umdjs/umd returnExports.js](https://github.com/umdjs/umd/blob/36fd1135ba44e758c7371e7af72295acdebce010/templates/returnExports.js#L30):
  - `}(typeof self !== 'undefined' ? self : this, function (b) {`

I propose to use Rollup-style global detection, to be compatible with Maplibre. Rollup is [licensed under MIT](https://github.com/rollup/rollup/blob/master/LICENSE-CORE.md), which is supposed to be functionally equivalent to ISC.

- [fixed minimal example](https://plnkr.co/edit/aRwsW1ii5EWvGQFr?open=lib%2Fscript.js&preview)
- [lazy loading demo](https://plnkr.co/edit/OP9WoZUqJHPCMq52?open=lib%2FMaplibreGlLazyLoader.js&preview)  
  (filter devtools Network tab by `.js` and observe when activating the Hillshading overlay)
  - the use case is to only load Maplibre when the layer is actually added to the map  
   

The second commit changes uses of `window` to `root`.