### PR TITLE
Fix #29 - allow MapLibre GL JS to move to any latitude

### DIFF
--- a/debug/README.md
+++ b/debug/README.md
@@ -1,0 +1,5 @@
+# Debugging Examples
+
+These files reproduce difficult to test issues and are used for debugging specific issues.
+
+* [`max-latitude-bug-reproduction.html`](./max-latitude-bug-reproduction.html) reproduces [#29](https://github.com/maplibre/maplibre-gl-leaflet/issues/29);

--- a/debug/max-latitude-bug-reproduction.html
+++ b/debug/max-latitude-bug-reproduction.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>WebGL</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html,
+    body,
+    #map {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+    }
+  </style>
+
+  <!-- Leaflet -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.8.0/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.8.0/dist/leaflet.js"></script>
+
+  <!-- Maplibre GL -->
+  <link href="https://unpkg.com/maplibre-gl@2.2.1/dist/maplibre-gl.css" rel='stylesheet' />
+  <script src="https://unpkg.com/maplibre-gl@2.2.1/dist/maplibre-gl.js"></script>
+
+</head>
+
+<body>
+  <div id="map"></div>
+
+  <script src="../leaflet-maplibre-gl.js"></script>
+  <script>
+    var map = L.map('map', {}).setView([0, 0], 2);
+
+    L.marker([179, 0])
+      .bindPopup("Hello <b>Leaflet GL</b>!<br>Whoa, it works!")
+      .addTo(map)
+      .openPopup();
+
+    var gl = L.maplibreGL({
+      // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style
+      style: 'https://api.maptiler.com/maps/topo/style.json?key=gbetYLSD5vR8MdtZ88AQ'
+    }).addTo(map);
+  </script>
+</body>
+
+</html>

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -127,6 +127,8 @@
 
             // allow GL base map to pan beyond min/max latitudes
             this._glMap.transform.latRange = null;
+            this._glMap.transform.maxValidLatitude = Infinity;
+
             this._transformGL(this._glMap);
 
             if (this._glMap._canvas.canvas) {


### PR DESCRIPTION
Turns out all we needed to do to fix #29 was allow MapLibre to move the map to any latitude. This also includes a debug folder with an example.