### PR TITLE
fix: update types to use correct maplibre-gl types

### DIFF
--- a/leaflet-maplibre-gl.d.ts
+++ b/leaflet-maplibre-gl.d.ts
@@ -1,13 +1,13 @@
 import * as L from 'leaflet';
-import { Map, MapOptions } from 'maplibre-gl';
+import { Map as LibreGLMap, MapOptions as LibreGLMapOptions } from 'maplibre-gl';
 
 
 declare module 'leaflet' {
-    type LeafletMaplibreGLOptions = Omit<MapOptions, "container">;
+    type LeafletMaplibreGLOptions = Omit<LibreGLMapOptions, "container">;
 
     class MaplibreGL extends L.Layer {
         constructor(options: LeafletMaplibreGLOptions);
-        getMaplibreMap(): Map
+        getMaplibreMap(): LibreGLMap
         getCanvas(): HTMLCanvasElement
         getSize(): L.Point
         getBounds(): L.LatLngBounds


### PR DESCRIPTION
In some cases the types for Map and MapOptions might be selected from leaflet instead of maplibre-gl. This solves it by mapping the name of those types to something else so they can't be overriden by leaflet.

Solves #40