### PR TITLE
Add attribution handling to the layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.0.23 - 2024-11-17
+
+### Added
+
+- Add attribution handling to the Leaflet layer based on the `attributionControl` option and the source's `attribution` property
+
 ## 0.0.22 - 2024-07-08
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-leaflet",
-  "version": "0.0.21",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-leaflet",
-      "version": "0.0.21",
+      "version": "0.0.23",
       "license": "ISC",
       "devDependencies": {
         "jshint": "^2.10.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-leaflet",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Supports adding Maplibre GL Web to a Leaflet Map as a layer",
   "main": "leaflet-maplibre-gl.js",
   "directories": {


### PR DESCRIPTION
## Summary
This PR introduces enhancements to improve attribution handling. The key changes include dynamic retrieval of attributions from MapLibre styles, support for custom attribution controls, and additional events to synchronize attribution updates.

## Key Changes

### Custom Attribution Handling
- Feature: The `getAttribution` method now dynamically retrieves attributions from MapLibre style sources if `attributionControl` is enabled and no custom attribution is specified.
- Fallback: If no valid attributions are found, it defaults to an empty string.

### Automatic Attribution Update on Map Load
  - Added an event listener to the `load` event of the MapLibre instance to update the Leaflet map's attribution control dynamically after the MapLibre map has fully loaded.

## Why This Change?

- Dynamic Attribution Support: Automatically gathering attributions from MapLibre sources ensures compliance with licensing terms without requiring manual input.
- Customization Flexibility: Developers can specify their own attributions via `options.attributionControl.customAttribution` when needed.
