### PR TITLE
Fix: Ensure compatibility with MapLibre GL v3, v4, and v5

### DIFF
--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -168,8 +168,21 @@
             });
 
             // allow GL base map to pan beyond min/max latitudes
-            this._glMap.transform.latRange = null;
-            this._glMap.transform.maxValidLatitude = Infinity;
+            // Defensively check if properties are writable before setting them,
+            // ensuring compatibility with both old and new versions of MapLibre GL JS.
+            const transformProto = Object.getPrototypeOf(this._glMap.transform);
+
+            const latRangeDescriptor = Object.getOwnPropertyDescriptor(transformProto, 'latRange');
+            if (!latRangeDescriptor || latRangeDescriptor.set || latRangeDescriptor.writable) {
+                this._glMap.transform.latRange = null;
+            }
+
+            // Although this property is obsolete in modern versions, we apply the same
+            // defensive check for robust backward compatibility.
+            const maxValidLatitudeDescriptor = Object.getOwnPropertyDescriptor(transformProto, 'maxValidLatitude');
+            if (!maxValidLatitudeDescriptor || maxValidLatitudeDescriptor.set || maxValidLatitudeDescriptor.writable) {
+                this._glMap.transform.maxValidLatitude = Infinity;
+            }
 
             this._transformGL(this._glMap);
 


### PR DESCRIPTION
#### **Problem**

When using `@maplibre/maplibre-gl-leaflet` with modern versions of `maplibre-gl` (v5.x), the map fails to initialize, throwing the following `TypeError`:

```
Uncaught TypeError: Cannot set property latRange of #<Lt> which has only a getter
```

This error occurs during the layer's `onAdd` lifecycle, specifically within the `_initGL` function when the plugin attempts to set `this._glMap.transform.latRange = null;`.

#### **Cause**

The root cause is a breaking change introduced in `maplibre-gl` v5 (could be v4? not sure). The `transform.latRange` property, which was previously a simple writable property, was refactored into a read-only "getter" property for performance and stability.

A simple deletion of the line would fix the issue for v4/v5 users but would break backward compatibility for users who are still on `maplibre-gl` v3, where this property assignment is still valid.

#### **Solution**

This pull request introduces a backward-compatible solution that works across all supported versions of `maplibre-gl`.

Instead of deleting the legacy code, this fix defensively checks if the `transform.latRange` property is writable before attempting to set it. It uses `Object.getOwnPropertyDescriptor()` to inspect the property's metadata. The property is only set if:
1.  A property descriptor does not exist on the prototype (meaning it's a simple, writable instance property).
2.  The descriptor explicitly has a `set` method.
3.  The descriptor's `writable` attribute is `true`.

On modern `maplibre-gl` versions, the descriptor for `latRange` has a `get` method but no `set` method, so the condition correctly fails and the assignment is skipped, preventing the crash. On older versions like v3, the condition passes and the original logic is preserved.

The same defensive check has been applied to the now-obsolete `maxValidLatitude` property for consistency and to future-proof the plugin against similar potential changes.

This approach ensures that the plugin works for all users, regardless of which compatible `maplibre-gl` version they have installed.

#### **How to Test and Verify**

This fix can be verified by testing against both old and new versions of `maplibre-gl`.

**Test 1: Modern Version (v5.x)**
1.  In `package.json`, ensure `maplibre-gl` is set to `"^5.6.0"`.
2.  Run `npm install`.
3.  Observe that the map loads successfully **without any `TypeError`**.
4.  (Optional) Add a `console.log` inside the `if` block; observe that it is **not** called for `latRange`.

**Test 2: Legacy Version (v3.x)**
1.  In `package.json`, downgrade `maplibre-gl` to `"~3.6.2"`.
2.  Run `npm install`.
3.  Observe that the map loads successfully **without any `TypeError`**.
4.  (Optional) Add a `console.log` inside the `if` block; observe that it **is** called for `latRange`, proving backward compatibility is maintained.