### PR TITLE
fix: Invoke getAttribution to pass string result to addAttribution

### DIFF
--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -163,7 +163,7 @@
             this._glMap.on('load', function () {
                 // Force attribution update
                 if (_map && _map.attributionControl) {
-                    _map.attributionControl.addAttribution(_getAttribution);
+                    _map.attributionControl.addAttribution(_getAttribution());
                 }
             });
 


### PR DESCRIPTION
## The problem:

We're passing the _getAttribution function object itself as the argument to addAttribution rather than the string value that gets returned by calling getAttribution(). 

The addAttribution method expects a string to be passed to it, not a function object. 

When a function is used where a string is expected, JavaScript automatically tries to convert it to a string by implicitly calling its .toString() method

Calling .toString() on a function created with .bind() results in the string function () { [native code] }

## Validation

Screenshot of what happens on the attribution (this is running the latest main branch code from my forked repo):
<img width="505" height="29" alt="image" src="https://github.com/user-attachments/assets/fb2d33e9-02c7-46f3-8589-3c9af682c61c" />

Screenshot running with the 'fix' branch on my forked repo (notice the function native code is not showing anymore, since we're not appending that to the attribution string anymore):
<img width="387" height="31" alt="image" src="https://github.com/user-attachments/assets/7669d424-49d8-42ed-aafe-1c361c77e8a0" />

## Reproduce/Observe the behavior of how using bind causes this:

To see how the function() { [native code] } occurs in a 'toy' example, try this out:

```javascript
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>Function Binding Test</title>
    <script src="https://cdn.tailwindcss.com"></script>
    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
    <style>
        body {
            font-family: 'Inter', sans-serif;
        }
        .output-box {
            min-height: 5rem;
            transition: all 0.2s ease-in-out;
        }
    </style>
</head>
<body class="bg-gray-100 flex items-center justify-center min-h-screen">

    <div class="bg-white p-8 rounded-xl shadow-md w-full max-w-2xl">
        <h1 class="text-2xl font-bold text-center text-gray-800 mb-6">Demonstrating the `.bind()` Bug</h1>
        <p class="text-center text-gray-600 mb-8">This shows the difference between passing a function object vs. passing its return value.</p>

        <!-- The function that expects a string -->
        <div class="mb-6 bg-blue-50 p-4 rounded-lg">
            <h2 class="text-lg font-semibold text-blue-800 mb-2">The Receiver Function</h2>
            <p class="text-sm text-blue-700">This function, `appendToLog`, expects a string and displays it in the corresponding box below.</p>
            <pre class="bg-blue-100 text-blue-900 p-2 rounded mt-2 text-sm"><code>function appendToLog(logId, message) {
    const logEl = document.getElementById(logId);
    // JS converts 'message' to a string here!
    logEl.textContent = message;
}</code></pre>
        </div>

        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
            <!-- Buggy Version -->
            <div>
                <h3 class="font-semibold text-lg text-red-600 mb-3 text-center">1. The Buggy Way</h3>
                <button id="buggy-button" class="w-full bg-red-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-opacity-50 transition-colors">
                    Pass the Function Object
                </button>
                <div id="buggy-log" class="output-box bg-gray-50 border mt-4 p-4 rounded-lg text-center text-gray-700 font-mono break-all">
                    Click the button...
                </div>
            </div>

            <!-- Correct Version -->
            <div>
                <h3 class="font-semibold text-lg text-green-600 mb-3 text-center">2. The Correct Way</h3>
                <button id="correct-button" class="w-full bg-green-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-opacity-50 transition-colors">
                    Execute the Function
                </button>
                <div id="correct-log" class="output-box bg-gray-50 border mt-4 p-4 rounded-lg text-center text-gray-700 font-mono break-all">
                    Click the button...
                </div>
            </div>
        </div>

    </div>

    <script>
        // 1. The original function that returns the string we actually want.
        function getAttributionString() {
            return "© MapProvider, © TileVendor";
        }

        // 2. We create a bound version of it.
        // We use 'null' for 'this' because the function doesn't use 'this' internally.
        // This creates a new function whose source code is native.
        const boundGetAttribution = getAttributionString.bind(null);

        // 3. This is the function that expects a string argument (like your 'addAttribution').
        function appendToLog(logId, message) {
            const logEl = document.getElementById(logId);
            // If 'message' is not a string, JavaScript will implicitly
            // call its .toString() method here.
            logEl.textContent = `Received: ${message}`;
        }

        // --- Event Listeners ---

        // The buggy implementation: Pass the function OBJECT itself.
        document.getElementById('buggy-button').addEventListener('click', function() {
            appendToLog('buggy-log', boundGetAttribution);
        });

        // The correct implementation: EXECUTE the function and pass its RETURN VALUE.
        document.getElementById('correct-button').addEventListener('click', function() {
            appendToLog('correct-log', boundGetAttribution());
        });

    </script>
</body>
</html>
```

