### PR TITLE
Fix max latitude and map sync in MapLibre v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a binding from [MapLibre GL JS](https://maplibre.org) to the familiar
 
 ```javascript
 var map = L.map("map", {
-    maxBounds: [[180, -540], [-180, 540]], // restrict bounds to avoid max latitude issues with MapLibre GL
+    maxBounds: [[180, -Infinity], [-180, Infinity]], // restrict bounds to avoid max latitude issues with MapLibre GL
     maxBoundsViscosity: 1, // make the max bounds "solid" so users cannot pan past them
   }).setView([38.912753, -77.032194], 15);
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,18 @@ This is a binding from [MapLibre GL JS](https://maplibre.org) to the familiar
 ## Code example
 
 ```javascript
-var map = L.map("map").setView([38.912753, -77.032194], 15);
+var map = L.map("map"
+  {
+    maxBounds: [[180, -540], [-180, 540]], // restrict bounds to avoid max latitude issues with MapLibre GL
+    maxBoundsViscosity: 1, // make the max bounds "solid" so users cannot pan past them
+  }
+).setView([38.912753, -77.032194], 15);
+
 L.marker([38.912753, -77.032194])
   .bindPopup("Hello <b>Leaflet GL</b>!<br>Whoa, it works!")
   .addTo(map)
   .openPopup();
+
 var gl = L.maplibreGL({
   style: "mapbox://styles/mapbox/bright-v8",
 }).addTo(map);
@@ -72,6 +79,7 @@ Here are the main differences between a "pure" maplibre-gl-js map and a Leaflet 
 
 - No rotation / bearing / pitch support
 - Slower performances: When using maplibre-gl-leaflet, maplibre-gl-js is set as not interactive. Leaflet receives the touch/mouse events and updates the maplibre-gl-js map behind the scenes. Because maplibre-gl-js doesn't redraw as fast as Leaflet, the map can seem slower.
+- MapLibre restricts the maximum latitude of the map in a stricter way then Leaflet. In order to maximize compatibility it it is recommended to set a `maxBounds: [[180, -Infinity], [-180, Infinity]]` and `maxBoundsViscosity: 1` on your Leaflet `Map` to prevent users from panning past the minimum and maximum latitude supported by MapLibre.
 
 On the bright side, the maplibre-gl-leaflet binding will allow you to use all the leaflet features and plugins.
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@ This is a binding from [MapLibre GL JS](https://maplibre.org) to the familiar
 ## Code example
 
 ```javascript
-var map = L.map("map"
-  {
+var map = L.map("map", {
     maxBounds: [[180, -540], [-180, 540]], // restrict bounds to avoid max latitude issues with MapLibre GL
     maxBoundsViscosity: 1, // make the max bounds "solid" so users cannot pan past them
-  }
-).setView([38.912753, -77.032194], 15);
+  }).setView([38.912753, -77.032194], 15);
 
 L.marker([38.912753, -77.032194])
   .bindPopup("Hello <b>Leaflet GL</b>!<br>Whoa, it works!")

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a binding from [MapLibre GL JS](https://maplibre.org) to the familiar
 var map = L.map("map", {
     maxBounds: [[180, -Infinity], [-180, Infinity]], // restrict bounds to avoid max latitude issues with MapLibre GL
     maxBoundsViscosity: 1, // make the max bounds "solid" so users cannot pan past them
+    minZoom: 1 // prevent sync issues at zoom 0
   }).setView([38.912753, -77.032194], 15);
 
 L.marker([38.912753, -77.032194])
@@ -78,6 +79,7 @@ Here are the main differences between a "pure" maplibre-gl-js map and a Leaflet 
 - No rotation / bearing / pitch support
 - Slower performances: When using maplibre-gl-leaflet, maplibre-gl-js is set as not interactive. Leaflet receives the touch/mouse events and updates the maplibre-gl-js map behind the scenes. Because maplibre-gl-js doesn't redraw as fast as Leaflet, the map can seem slower.
 - MapLibre restricts the maximum latitude of the map in a stricter way then Leaflet. In order to maximize compatibility it it is recommended to set a `maxBounds: [[180, -Infinity], [-180, Infinity]]` and `maxBoundsViscosity: 1` on your Leaflet `Map` to prevent users from panning past the minimum and maximum latitude supported by MapLibre.
+- Setting `minZoom: 1` is also recommended to reduce some issues with the map syncing at zoom level 0.
 
 On the bright side, the maplibre-gl-leaflet binding will allow you to use all the leaflet features and plugins.
 

--- a/debug/max-latitude-bug-reproduction.html
+++ b/debug/max-latitude-bug-reproduction.html
@@ -41,8 +41,7 @@
       .addTo(map)
 
     var gl = L.maplibreGL({
-      // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style
-      style: 'https://api.maptiler.com/maps/topo/style.json?key=gbetYLSD5vR8MdtZ88AQ'
+      style: 'https://demotiles.maplibre.org/style.json'
     }).addTo(map);
   </script>
 </body>

--- a/debug/max-latitude-bug-reproduction.html
+++ b/debug/max-latitude-bug-reproduction.html
@@ -20,8 +20,8 @@
   <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
 
   <!-- Maplibre GL -->
-  <link href="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.css" rel='stylesheet' />
-  <script src="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.js"></script>
+  <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel='stylesheet' />
+  <script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
 
 </head>
 
@@ -30,12 +30,15 @@
 
   <script src="../leaflet-maplibre-gl.js"></script>
   <script>
-    var map = L.map('map', {}).setView([0, 0], 2);
+    var map = L.map('map').setView([0, 0], 2);
 
     L.marker([179, 0])
       .bindPopup("Hello <b>Leaflet GL</b>!<br>Whoa, it works!")
       .addTo(map)
-      .openPopup();
+
+    L.marker([0, 0])
+      .bindPopup("Hello <b>Leaflet GL</b>!<br>Whoa, it works!")
+      .addTo(map)
 
     var gl = L.maplibreGL({
       // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -1,44 +1,51 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-    <title>WebGL</title>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>
-      html, body, #map {
-        width: 100%;
-        height: 100%;
-        margin: 0;
-      }
-    </style>
+  <title>WebGL</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html,
+    body,
+    #map {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+    }
+  </style>
 
-    <!-- Leaflet -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
+  <!-- Leaflet -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
 
-    <!-- Maplibre GL -->
-    <link href="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.css" rel='stylesheet' />
-    <script src="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.js"></script>
+  <!-- Maplibre GL -->
+  <link href="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.css" rel='stylesheet' />
+  <script src="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.js"></script>
 
 </head>
 
 <body>
-<div id="map"></div>
+  <div id="map"></div>
 
-<script src="../leaflet-maplibre-gl.js"></script>
-<script>
-var map = L.map('map').setView([38.912753, -77.032194], 15);
+  <script src="../leaflet-maplibre-gl.js"></script>
+  <script>
+    var map = L.map('map', {
+      maxBounds: [[180, -540], [-180, 540]], // restrict bounds to avoid max latitude issues with MapLibre GL
+      maxBoundsViscosity: 1,
+    }).setView([38.912753, -77.032194], 15);
 
-L.marker([38.912753, -77.032194])
-    .bindPopup("Hello <b>Leaflet GL</b>!<br>Whoa, it works!")
-    .addTo(map)
-    .openPopup();
+    L.marker([38.912753, -77.032194])
+      .bindPopup("Hello <b>Leaflet GL</b>!<br>Whoa, it works!")
+      .addTo(map)
+      .openPopup();
 
-var gl = L.maplibreGL({
-    // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style
-    style: 'https://api.maptiler.com/maps/topo/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
-}).addTo(map);
+    var gl = L.maplibreGL({
+      // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style
+      style: 'https://api.maptiler.com/maps/topo/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
+    }).addTo(map);
 
-</script>
+  </script>
 </body>
+
 </html>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -20,8 +20,8 @@
   <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
 
   <!-- Maplibre GL -->
-  <link href="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.css" rel='stylesheet' />
-  <script src="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.js"></script>
+  <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel='stylesheet' />
+  <script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
 
 </head>
 
@@ -32,7 +32,7 @@
   <script>
     var map = L.map('map', {
       maxBounds: [[180, -540], [-180, 540]], // restrict bounds to avoid max latitude issues with MapLibre GL
-      maxBoundsViscosity: 1,
+      maxBoundsViscosity: 1, // make the max bounds "solid" so users cannot pan past them
     }).setView([38.912753, -77.032194], 15);
 
     L.marker([38.912753, -77.032194])
@@ -41,8 +41,7 @@
       .openPopup();
 
     var gl = L.maplibreGL({
-      // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style
-      style: 'https://api.maptiler.com/maps/topo/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
+      style: 'https://demotiles.maplibre.org/style.json'
     }).addTo(map);
 
   </script>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -1,47 +1,52 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-    <title>WebGL</title>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>
-      html, body, #map {
-        width: 100%;
-        height: 100%;
-        margin: 0;
-      }
-    </style>
+  <title>WebGL</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html,
+    body,
+    #map {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+    }
+  </style>
 
-    <!-- Leaflet -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
+  <!-- Leaflet -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
 
-    <!-- Maplibre GL -->
-    <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel='stylesheet' />
-    <script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
+  <!-- Maplibre GL -->
+  <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel='stylesheet' />
+  <script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
 
 </head>
 
 <body>
-<div id="map"></div>
+  <div id="map"></div>
 
-<script src="../leaflet-maplibre-gl.js"></script>
-<script>
-var map = L.map('map', {
-  maxBounds: [[180, -540], [-180, 540]], // restrict bounds to avoid max latitude issues with MapLibre GL
-  maxBoundsViscosity: 1, // make the max bounds "solid" so users cannot pan past them
-}).setView([38.912753, -77.032194], 15);
+  <script src="../leaflet-maplibre-gl.js"></script>
+  <script>
+    var map = L.map('map', {
+      maxBounds: [[180, -Infinity], [-180, Infinity]], // restrict bounds to avoid max latitude issues with MapLibre GL
+      maxBoundsViscosity: 1, // make the max bounds "solid" so users cannot pan past them
+      minZoom: 1 // prevent sync issues at zoom 0
+    }).setView([38.912753, -77.032194], 2);
 
-L.marker([38.912753, -77.032194])
-    .bindPopup("Hello <b>Leaflet GL</b>!<br>Whoa, it works!")
-    .addTo(map)
-    .openPopup();
+    L.marker([38.912753, -77.032194])
+      .bindPopup("Hello <b>Leaflet GL</b>!<br>Whoa, it works!")
+      .addTo(map)
+      .openPopup();
 
-var gl = L.maplibreGL({
-    // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style
-    style: 'https://demotiles.maplibre.org/style.json'
-}).addTo(map);
+    var gl = L.maplibreGL({
+      // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style
+      style: 'https://demotiles.maplibre.org/style.json'
+    }).addTo(map);
 
-</script>
+  </script>
 </body>
+
 </html>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -1,50 +1,47 @@
 <!DOCTYPE html>
 <html>
-
 <head>
-  <title>WebGL</title>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style>
-    html,
-    body,
-    #map {
-      width: 100%;
-      height: 100%;
-      margin: 0;
-    }
-  </style>
+    <title>WebGL</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      html, body, #map {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+    </style>
 
-  <!-- Leaflet -->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
-  <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
+    <!-- Leaflet -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
 
-  <!-- Maplibre GL -->
-  <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel='stylesheet' />
-  <script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
+    <!-- Maplibre GL -->
+    <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel='stylesheet' />
+    <script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
 
 </head>
 
 <body>
-  <div id="map"></div>
+<div id="map"></div>
 
-  <script src="../leaflet-maplibre-gl.js"></script>
-  <script>
-    var map = L.map('map', {
-      maxBounds: [[180, -540], [-180, 540]], // restrict bounds to avoid max latitude issues with MapLibre GL
-      maxBoundsViscosity: 1, // make the max bounds "solid" so users cannot pan past them
-    }).setView([38.912753, -77.032194], 15);
+<script src="../leaflet-maplibre-gl.js"></script>
+<script>
+var map = L.map('map', {
+  maxBounds: [[180, -540], [-180, 540]], // restrict bounds to avoid max latitude issues with MapLibre GL
+  maxBoundsViscosity: 1, // make the max bounds "solid" so users cannot pan past them
+}).setView([38.912753, -77.032194], 15);
 
-    L.marker([38.912753, -77.032194])
-      .bindPopup("Hello <b>Leaflet GL</b>!<br>Whoa, it works!")
-      .addTo(map)
-      .openPopup();
+L.marker([38.912753, -77.032194])
+    .bindPopup("Hello <b>Leaflet GL</b>!<br>Whoa, it works!")
+    .addTo(map)
+    .openPopup();
 
-    var gl = L.maplibreGL({
-      style: 'https://demotiles.maplibre.org/style.json'
-    }).addTo(map);
+var gl = L.maplibreGL({
+    // get your own MapTiler token at https://cloud.maptiler.com/ or use MapBox style
+    style: 'https://demotiles.maplibre.org/style.json'
+}).addTo(map);
 
-  </script>
+</script>
 </body>
-
 </html>

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -217,7 +217,6 @@
           latRangeDescriptor.set ||
           latRangeDescriptor.writable
         ) {
-          console.log("MapLibre v3 setting latRange to null");
           this._glMap.transform.latRange = null;
         }
 
@@ -233,7 +232,6 @@
           maxValidLatitudeDescriptor.set ||
           maxValidLatitudeDescriptor.writable
         ) {
-          console.log("MapLibre v4 setting maxValidLatitude to Infinity");
           this._glMap.transform.maxValidLatitude = Infinity;
         }
 
@@ -243,7 +241,6 @@
           this._glMap.transform._helper &&
           this._glMap.transform._helper._latRange
         ) {
-          console.log("MapLibre v5 setting _latRange to [-Infinity, Infinity]");
           this._glMap.transform._helper._latRange = [-Infinity, Infinity];
         }
 

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -126,7 +126,7 @@
         },
 
         _roundPoint: function (p) {
-            return {x: Math.round(p.x), y: Math.round(p.y)};
+            return { x: Math.round(p.x), y: Math.round(p.y) };
         },
 
         _initContainer: function () {
@@ -167,15 +167,6 @@
                 }
             });
 
-            // once the map renders for the first time, we update the map
-            // this is necessary to ensure the map is rendered correctly
-            // when the map starts zoomed out beyond the min/max latitudes
-            this._glMap.once("render", () => {
-                this._update();
-                this._glMap.triggerRepaint();
-                canvas.style.opacity = 1;
-            });
-
             // allow GL base map to pan beyond min/max latitudes
             // Defensively check if properties are writable before setting them,
             // ensuring compatibility with both old and new versions of MapLibre GL JS.
@@ -214,12 +205,6 @@
             var canvas = this._glMap._actualCanvas;
             L.DomUtil.addClass(canvas, 'leaflet-image-layer');
             L.DomUtil.addClass(canvas, 'leaflet-zoom-animated');
-
-            // hide the map until it is loaded, to prevent flickering
-            // this is a workaround for when the map is zoomed out beyond the
-            // min/max latitudes, which causes the map to flicker until it is interacted with
-            // after the map renders for the first time, we set the opacity to 1
-            canvas.style.opacity = 0;
 
             if (this.options.interactive) {
                 L.DomUtil.addClass(canvas, 'leaflet-interactive');

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -1,335 +1,416 @@
 (function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD
-        define(['leaflet', 'maplibre-gl'], factory);
-    } else if (typeof exports === 'object') {
-        // Node, CommonJS-like
-        module.exports = factory(require('leaflet'), require('maplibre-gl'));
-    } else {
-        // Browser globals (root is window)
-        root.returnExports = factory(root.L, root.maplibregl);
-    }
-}(typeof globalThis !== 'undefined' ? globalThis : this || self, function (L, maplibregl) {
+  if (typeof define === "function" && define.amd) {
+    // AMD
+    define(["leaflet", "maplibre-gl"], factory);
+  } else if (typeof exports === "object") {
+    // Node, CommonJS-like
+    module.exports = factory(require("leaflet"), require("maplibre-gl"));
+  } else {
+    // Browser globals (root is window)
+    root.returnExports = factory(root.L, root.maplibregl);
+  }
+})(
+  typeof globalThis !== "undefined" ? globalThis : this || self,
+  function (L, maplibregl) {
     L.MaplibreGL = L.Layer.extend({
-        options: {
-            updateInterval: 32,
-            // How much to extend the overlay view (relative to map size)
-            // e.g. 0.1 would be 10% of map view in each direction
-            padding: 0.1,
-            // whether or not to register the mouse and keyboard
-            // events on the maplibre overlay
-            interactive: false,
-            // set the tilepane as the default pane to draw gl tiles
-            pane: 'tilePane'
-        },
+      options: {
+        updateInterval: 32,
+        // How much to extend the overlay view (relative to map size)
+        // e.g. 0.1 would be 10% of map view in each direction
+        padding: 0.1,
+        // whether or not to register the mouse and keyboard
+        // events on the maplibre overlay
+        interactive: false,
+        // set the tilepane as the default pane to draw gl tiles
+        pane: "tilePane",
+      },
 
-        initialize: function (options) {
-            L.setOptions(this, options);
+      initialize: function (options) {
+        L.setOptions(this, options);
 
-            // setup throttling the update event when panning
-            this._throttledUpdate = L.Util.throttle(this._update, this.options.updateInterval, this);
-        },
+        // setup throttling the update event when panning
+        this._throttledUpdate = L.Util.throttle(
+          this._update,
+          this.options.updateInterval,
+          this
+        );
+      },
 
-        onAdd: function (map) {
-            if (!this._container) {
-                this._initContainer();
-            }
-
-            var paneName = this.getPaneName();
-            map.getPane(paneName).appendChild(this._container);
-
-            this._initGL();
-
-            this._offset = this._map.containerPointToLayerPoint([0, 0]);
-
-            // work around https://github.com/mapbox/mapbox-gl-leaflet/issues/47
-            if (map.options.zoomAnimation) {
-                L.DomEvent.on(map._proxy, L.DomUtil.TRANSITION_END, this._transitionEnd, this);
-            }
-        },
-
-        onRemove: function (map) {
-            if (this._map._proxy && this._map.options.zoomAnimation) {
-                L.DomEvent.off(this._map._proxy, L.DomUtil.TRANSITION_END, this._transitionEnd, this);
-            }
-            var paneName = this.getPaneName();
-            map.getPane(paneName).removeChild(this._container);
-
-            this._glMap.remove();
-            this._glMap = null;
-        },
-
-        getEvents: function () {
-            return {
-                move: this._throttledUpdate, // sensibly throttle updating while panning
-                zoomanim: this._animateZoom, // applys the zoom animation to the <canvas>
-                zoom: this._pinchZoom, // animate every zoom event for smoother pinch-zooming
-                zoomstart: this._zoomStart, // flag starting a zoom to disable panning
-                zoomend: this._zoomEnd,
-                resize: this._resize
-            };
-        },
-
-        // https://leafletjs.com/reference.html#layer-getattribution
-        getAttribution: function () {
-            // Return custom attribution if specified in options
-            if (this.options.attributionControl) {
-                return this.options.attributionControl.customAttribution;
-            }
-
-            // Gather attributions from MapLibre styles
-            var map = this._glMap;
-            if (map && this.options.attributionControl !== false) {
-                var style = map.getStyle();
-                if (style && style.sources) {
-                    return Object.keys(style.sources)
-                        .map(function (sourceId) {
-                            var source = map.getSource(sourceId);
-                            return (source && typeof source.attribution === 'string') ? source.attribution.trim() : null;
-                        })
-                        .filter(Boolean) // Remove null/undefined values
-                        .join(', ');
-                }
-            }
-
-            return '';
-        },
-
-        getMaplibreMap: function () {
-            return this._glMap;
-        },
-
-        getCanvas: function () {
-            return this._glMap.getCanvas();
-        },
-
-        getSize: function () {
-            return this._map.getSize().multiplyBy(1 + this.options.padding * 2);
-        },
-
-        getBounds: function () {
-            var halfSize = this.getSize().multiplyBy(0.5);
-            var center = this._map.latLngToContainerPoint(this._map.getCenter());
-            return L.latLngBounds(
-                this._map.containerPointToLatLng(center.subtract(halfSize)),
-                this._map.containerPointToLatLng(center.add(halfSize))
-            );
-        },
-
-        getContainer: function () {
-            return this._container;
-        },
-
-        // returns the pane name set in options if it is a valid pane, defaults to tilePane
-        getPaneName: function () {
-            return this._map.getPane(this.options.pane) ? this.options.pane : 'tilePane';
-        },
-
-        _roundPoint: function (p) {
-            return {x: Math.round(p.x), y: Math.round(p.y)};
-        },
-
-        _initContainer: function () {
-            var container = this._container = L.DomUtil.create('div', 'leaflet-gl-layer');
-            this._resizeContainer();
-
-            var offset = this._map.getSize().multiplyBy(this.options.padding);
-
-            var topLeft = this._map.containerPointToLayerPoint([0, 0]).subtract(offset);
-
-            L.DomUtil.setPosition(container, this._roundPoint(topLeft));
-        },
-
-        _resizeContainer: function () {
-            var size = this.getSize();
-            this._container.style.width = size.x + 'px';
-            this._container.style.height = size.y + 'px';
-        },
-
-        _initGL: function () {
-            var center = this._map.getCenter();
-
-            var options = L.extend({}, this.options, {
-                container: this._container,
-                center: [center.lng, center.lat],
-                zoom: this._map.getZoom() - 1,
-                attributionControl: false
-            });
-
-            this._glMap = new maplibregl.Map(options);
-
-            var _map = this._map;
-            var _getAttribution = this.getAttribution.bind(this);
-            this._glMap.on('load', function () {
-                // Force attribution update
-                if (_map && _map.attributionControl) {
-                    _map.attributionControl.addAttribution(_getAttribution);
-                }
-            });
-
-            // allow GL base map to pan beyond min/max latitudes
-            // Defensively check if properties are writable before setting them,
-            // ensuring compatibility with both old and new versions of MapLibre GL JS.
-            const transformProto = Object.getPrototypeOf(this._glMap.transform);
-
-            const latRangeDescriptor = Object.getOwnPropertyDescriptor(transformProto, 'latRange');
-            if (!latRangeDescriptor || latRangeDescriptor.set || latRangeDescriptor.writable) {
-                this._glMap.transform.latRange = null;
-            }
-
-            // Although this property is obsolete in modern versions, we apply the same
-            // defensive check for robust backward compatibility.
-            const maxValidLatitudeDescriptor = Object.getOwnPropertyDescriptor(transformProto, 'maxValidLatitude');
-            if (!maxValidLatitudeDescriptor || maxValidLatitudeDescriptor.set || maxValidLatitudeDescriptor.writable) {
-                this._glMap.transform.maxValidLatitude = Infinity;
-            }
-
-            this._transformGL(this._glMap);
-
-            if (this._glMap._canvas.canvas) {
-                // older versions of mapbox-gl surfaced the canvas differently
-                this._glMap._actualCanvas = this._glMap._canvas.canvas;
-            } else {
-                this._glMap._actualCanvas = this._glMap._canvas;
-            }
-
-            // treat child <canvas> element like L.ImageOverlay
-            var canvas = this._glMap._actualCanvas;
-            L.DomUtil.addClass(canvas, 'leaflet-image-layer');
-            L.DomUtil.addClass(canvas, 'leaflet-zoom-animated');
-            if (this.options.interactive) {
-                L.DomUtil.addClass(canvas, 'leaflet-interactive');
-            }
-            if (this.options.className) {
-                L.DomUtil.addClass(canvas, this.options.className);
-            }
-        },
-
-        _update: function (e) {
-            if (!this._map) {
-                return;
-            }
-            // update the offset so we can correct for it later when we zoom
-            this._offset = this._map.containerPointToLayerPoint([0, 0]);
-
-            if (this._zooming) {
-                return;
-            }
-
-            var container = this._container,
-                gl = this._glMap,
-                offset = this._map.getSize().multiplyBy(this.options.padding),
-                topLeft = this._map.containerPointToLayerPoint([0, 0]).subtract(offset);
-
-            L.DomUtil.setPosition(container, this._roundPoint(topLeft));
-
-            this._transformGL(gl);
-        },
-
-        _transformGL: function (gl) {
-            var center = this._map.getCenter();
-
-            // gl.setView([center.lat, center.lng], this._map.getZoom() - 1, 0);
-            // calling setView directly causes sync issues because it uses requestAnimFrame
-
-            var tr = gl._getTransformForUpdate(); // .clone() ?
-
-            if (tr.setCenter) {
-                // maplibre 5.0.0 and higher:
-                tr.setCenter(maplibregl.LngLat.convert([center.lng, center.lat]));
-                tr.setZoom(this._map.getZoom() - 1);
-                gl.transform.apply(tr);
-            } else {
-                // maplibre < 5.0.0
-                tr = gl.transform;
-                tr.center = maplibregl.LngLat.convert([center.lng, center.lat]);
-                tr.zoom = this._map.getZoom() - 1;
-            }
-
-            gl._fireMoveEvents();
-        },
-
-        // update the map constantly during a pinch zoom
-        _pinchZoom: function (e) {
-            this._glMap.jumpTo({
-                zoom: this._map.getZoom() - 1,
-                center: this._map.getCenter()
-            });
-        },
-
-        // borrowed from L.ImageOverlay
-        // https://github.com/Leaflet/Leaflet/blob/master/src/layer/ImageOverlay.js#L139-L144
-        _animateZoom: function (e) {
-            var scale = this._map.getZoomScale(e.zoom);
-            var padding = this._map.getSize().multiplyBy(this.options.padding * scale);
-            var viewHalf = this.getSize()._divideBy(2);
-            // corrections for padding (scaled), adapted from
-            // https://github.com/Leaflet/Leaflet/blob/master/src/map/Map.js#L1490-L1508
-            var topLeft = this._map.project(e.center, e.zoom)
-                ._subtract(viewHalf)
-                ._add(this._map._getMapPanePos()
-                    .add(padding))._round();
-            var offset = this._map.project(this._map.getBounds().getNorthWest(), e.zoom)
-                ._subtract(topLeft);
-
-            L.DomUtil.setTransform(
-                this._glMap._actualCanvas,
-                offset.subtract(this._offset),
-                scale
-            );
-        },
-
-        _zoomStart: function (e) {
-            this._zooming = true;
-        },
-
-        _zoomEnd: function () {
-            var scale = this._map.getZoomScale(this._map.getZoom());
-
-            L.DomUtil.setTransform(
-                this._glMap._actualCanvas,
-                // https://github.com/mapbox/mapbox-gl-leaflet/pull/130
-                null,
-                scale
-            );
-
-            this._zooming = false;
-
-            this._update();
-        },
-
-        _transitionEnd: function (e) {
-            L.Util.requestAnimFrame(function () {
-                var zoom = this._map.getZoom();
-                var center = this._map.getCenter();
-                var offset = this._map.latLngToContainerPoint(
-                    this._map.getBounds().getNorthWest()
-                );
-                this._resizeContainer();
-
-                // reset the scale and offset
-                L.DomUtil.setTransform(this._glMap._actualCanvas, offset, 1);
-
-                // enable panning once the gl map is ready again
-                this._glMap.once('moveend', L.Util.bind(function () {
-                    this._zoomEnd();
-                }, this));
-
-                // update the map position
-                this._glMap.jumpTo({
-                    center: center,
-                    zoom: zoom - 1
-                });
-            }, this);
-        },
-
-        _resize: function (e) {
-            this._transitionEnd(e);
+      onAdd: function (map) {
+        if (!this._container) {
+          this._initContainer();
         }
+
+        var paneName = this.getPaneName();
+        map.getPane(paneName).appendChild(this._container);
+
+        this._initGL();
+
+        this._offset = this._map.containerPointToLayerPoint([0, 0]);
+
+        // work around https://github.com/mapbox/mapbox-gl-leaflet/issues/47
+        if (map.options.zoomAnimation) {
+          L.DomEvent.on(
+            map._proxy,
+            L.DomUtil.TRANSITION_END,
+            this._transitionEnd,
+            this
+          );
+        }
+      },
+
+      onRemove: function (map) {
+        if (this._map._proxy && this._map.options.zoomAnimation) {
+          L.DomEvent.off(
+            this._map._proxy,
+            L.DomUtil.TRANSITION_END,
+            this._transitionEnd,
+            this
+          );
+        }
+        var paneName = this.getPaneName();
+        map.getPane(paneName).removeChild(this._container);
+
+        this._glMap.remove();
+        this._glMap = null;
+      },
+
+      getEvents: function () {
+        return {
+          move: this._throttledUpdate, // sensibly throttle updating while panning
+          zoomanim: this._animateZoom, // applys the zoom animation to the <canvas>
+          zoom: this._pinchZoom, // animate every zoom event for smoother pinch-zooming
+          zoomstart: this._zoomStart, // flag starting a zoom to disable panning
+          zoomend: this._zoomEnd,
+          resize: this._resize,
+        };
+      },
+
+      // https://leafletjs.com/reference.html#layer-getattribution
+      getAttribution: function () {
+        // Return custom attribution if specified in options
+        if (this.options.attributionControl) {
+          return this.options.attributionControl.customAttribution;
+        }
+
+        // Gather attributions from MapLibre styles
+        var map = this._glMap;
+        if (map && this.options.attributionControl !== false) {
+          var style = map.getStyle();
+          if (style && style.sources) {
+            return Object.keys(style.sources)
+              .map(function (sourceId) {
+                var source = map.getSource(sourceId);
+                return source && typeof source.attribution === "string"
+                  ? source.attribution.trim()
+                  : null;
+              })
+              .filter(Boolean) // Remove null/undefined values
+              .join(", ");
+          }
+        }
+
+        return "";
+      },
+
+      getMaplibreMap: function () {
+        return this._glMap;
+      },
+
+      getCanvas: function () {
+        return this._glMap.getCanvas();
+      },
+
+      getSize: function () {
+        return this._map.getSize().multiplyBy(1 + this.options.padding * 2);
+      },
+
+      getBounds: function () {
+        var halfSize = this.getSize().multiplyBy(0.5);
+        var center = this._map.latLngToContainerPoint(this._map.getCenter());
+        return L.latLngBounds(
+          this._map.containerPointToLatLng(center.subtract(halfSize)),
+          this._map.containerPointToLatLng(center.add(halfSize))
+        );
+      },
+
+      getContainer: function () {
+        return this._container;
+      },
+
+      // returns the pane name set in options if it is a valid pane, defaults to tilePane
+      getPaneName: function () {
+        return this._map.getPane(this.options.pane)
+          ? this.options.pane
+          : "tilePane";
+      },
+
+      _roundPoint: function (p) {
+        return { x: Math.round(p.x), y: Math.round(p.y) };
+      },
+
+      _initContainer: function () {
+        var container = (this._container = L.DomUtil.create(
+          "div",
+          "leaflet-gl-layer"
+        ));
+        this._resizeContainer();
+
+        var offset = this._map.getSize().multiplyBy(this.options.padding);
+
+        var topLeft = this._map
+          .containerPointToLayerPoint([0, 0])
+          .subtract(offset);
+
+        L.DomUtil.setPosition(container, this._roundPoint(topLeft));
+      },
+
+      _resizeContainer: function () {
+        var size = this.getSize();
+        this._container.style.width = size.x + "px";
+        this._container.style.height = size.y + "px";
+      },
+
+      _initGL: function () {
+        var center = this._map.getCenter();
+
+        var options = L.extend({}, this.options, {
+          container: this._container,
+          center: [center.lng, center.lat],
+          zoom: this._map.getZoom() - 1,
+          attributionControl: false,
+        });
+
+        this._glMap = new maplibregl.Map(options);
+
+        var _map = this._map;
+        var _getAttribution = this.getAttribution.bind(this);
+
+        this._glMap.on("load", () => {
+          // Force attribution update
+          if (_map && _map.attributionControl) {
+            _map.attributionControl.addAttribution(_getAttribution());
+          }
+        });
+
+        // once the map renders for the first time, we update the map
+        // this is necessary to ensure the map is rendered correctly
+        // and to prevent flickering when the map is zoomed out beyond the min/max latitudes
+        this._glMap.once("render", () => {
+          this._update();
+          this._glMap.triggerRepaint();
+          canvas.style.opacity = 1;
+        });
+
+        // allow GL base map to pan beyond min/max latitudes
+        // Defensively check if properties are writable before setting them,
+        // ensuring compatibility with both old and new versions of MapLibre GL JS.
+        // This supports MapLibre v3
+        const transformProto = Object.getPrototypeOf(this._glMap.transform);
+
+        const latRangeDescriptor = Object.getOwnPropertyDescriptor(
+          transformProto,
+          "latRange"
+        );
+        if (
+          !latRangeDescriptor ||
+          latRangeDescriptor.set ||
+          latRangeDescriptor.writable
+        ) {
+          console.log("MapLibre v3 setting latRange to null");
+          this._glMap.transform.latRange = null;
+        }
+
+        // Although this property is obsolete in modern versions, we apply the same
+        // defensive check for robust backward compatibility.
+        // This supports MapLibre v4
+        const maxValidLatitudeDescriptor = Object.getOwnPropertyDescriptor(
+          transformProto,
+          "maxValidLatitude"
+        );
+        if (
+          !maxValidLatitudeDescriptor ||
+          maxValidLatitudeDescriptor.set ||
+          maxValidLatitudeDescriptor.writable
+        ) {
+          console.log("MapLibre v4 setting maxValidLatitude to Infinity");
+          this._glMap.transform.maxValidLatitude = Infinity;
+        }
+
+        // check for the existence of _helper and _latRange in MapLibre
+        // this supports MapLibre v5
+        if (
+          this._glMap.transform._helper &&
+          this._glMap.transform._helper._latRange
+        ) {
+          console.log("MapLibre v5 setting _latRange to [-Infinity, Infinity]");
+          this._glMap.transform._helper._latRange = [-Infinity, Infinity];
+        }
+
+        this._update();
+
+        if (this._glMap._canvas.canvas) {
+          // older versions of mapbox-gl surfaced the canvas differently
+          this._glMap._actualCanvas = this._glMap._canvas.canvas;
+        } else {
+          this._glMap._actualCanvas = this._glMap._canvas;
+        }
+
+        // treat child <canvas> element like L.ImageOverlay
+        var canvas = this._glMap._actualCanvas;
+        L.DomUtil.addClass(canvas, "leaflet-image-layer");
+        L.DomUtil.addClass(canvas, "leaflet-zoom-animated");
+
+        // hide the map until it is loaded, to prevent flickering
+        // this is a workaround for when the map is zoomed out beyond the
+        // min/max latitudes, which causes the map to flicker until it is interacted with
+        // after the map renders for the frist time, we set the opacity to 1
+        canvas.style.opacity = 0;
+
+        if (this.options.interactive) {
+          L.DomUtil.addClass(canvas, "leaflet-interactive");
+        }
+
+        if (this.options.className) {
+          L.DomUtil.addClass(canvas, this.options.className);
+        }
+      },
+
+      _update: function (e) {
+        if (!this._map) {
+          return;
+        }
+
+        // update the offset so we can correct for it later when we zoom
+        this._offset = this._map.containerPointToLayerPoint([0, 0]);
+
+        if (this._zooming) {
+          return;
+        }
+
+        var container = this._container,
+          gl = this._glMap,
+          offset = this._map.getSize().multiplyBy(this.options.padding),
+          topLeft = this._map
+            .containerPointToLayerPoint([0, 0])
+            .subtract(offset);
+
+        L.DomUtil.setPosition(container, this._roundPoint(topLeft));
+
+        this._transformGL(gl);
+      },
+
+      _transformGL: function (gl) {
+        var center = this._map.getCenter();
+
+        // gl.setView([center.lat, center.lng], this._map.getZoom() - 1, 0);
+        // calling setView directly causes sync issues because it uses requestAnimFrame
+
+        var tr = gl._getTransformForUpdate(); // .clone() ?
+
+        if (tr.setCenter) {
+          // maplibre 5.0.0 and higher:
+          tr.setCenter(maplibregl.LngLat.convert([center.lng, center.lat]));
+          tr.setZoom(this._map.getZoom() - 1);
+          gl.transform.apply(tr);
+        } else {
+          // maplibre < 5.0.0
+          tr = gl.transform;
+          tr.center = maplibregl.LngLat.convert([center.lng, center.lat]);
+          tr.zoom = this._map.getZoom() - 1;
+        }
+
+        gl._fireMoveEvents();
+      },
+
+      // update the map constantly during a pinch zoom
+      _pinchZoom: function (e) {
+        this._glMap.jumpTo({
+          zoom: this._map.getZoom() - 1,
+          center: this._map.getCenter(),
+        });
+      },
+
+      // borrowed from L.ImageOverlay
+      // https://github.com/Leaflet/Leaflet/blob/master/src/layer/ImageOverlay.js#L139-L144
+      _animateZoom: function (e) {
+        var scale = this._map.getZoomScale(e.zoom);
+        var padding = this._map
+          .getSize()
+          .multiplyBy(this.options.padding * scale);
+        var viewHalf = this.getSize()._divideBy(2);
+        // corrections for padding (scaled), adapted from
+        // https://github.com/Leaflet/Leaflet/blob/master/src/map/Map.js#L1490-L1508
+        var topLeft = this._map
+          .project(e.center, e.zoom)
+          ._subtract(viewHalf)
+          ._add(this._map._getMapPanePos().add(padding))
+          ._round();
+        var offset = this._map
+          .project(this._map.getBounds().getNorthWest(), e.zoom)
+          ._subtract(topLeft);
+
+        L.DomUtil.setTransform(
+          this._glMap._actualCanvas,
+          offset.subtract(this._offset),
+          scale
+        );
+      },
+
+      _zoomStart: function (e) {
+        this._zooming = true;
+      },
+
+      _zoomEnd: function () {
+        var scale = this._map.getZoomScale(this._map.getZoom());
+
+        L.DomUtil.setTransform(
+          this._glMap._actualCanvas,
+          // https://github.com/mapbox/mapbox-gl-leaflet/pull/130
+          null,
+          scale
+        );
+
+        this._zooming = false;
+
+        this._update();
+      },
+
+      _transitionEnd: function (e) {
+        L.Util.requestAnimFrame(function () {
+          var zoom = this._map.getZoom();
+          var center = this._map.getCenter();
+          var offset = this._map.latLngToContainerPoint(
+            this._map.getBounds().getNorthWest()
+          );
+          this._resizeContainer();
+
+          // reset the scale and offset
+          L.DomUtil.setTransform(this._glMap._actualCanvas, offset, 1);
+
+          // enable panning once the gl map is ready again
+          this._glMap.once(
+            "moveend",
+            L.Util.bind(function () {
+              this._zoomEnd();
+            }, this)
+          );
+
+          // update the map position
+          this._glMap.jumpTo({
+            center: center,
+            zoom: zoom - 1,
+          });
+        }, this);
+      },
+
+      _resize: function (e) {
+        this._transitionEnd(e);
+      },
     });
 
     L.maplibreGL = function (options) {
-        return new L.MaplibreGL(options);
+      return new L.MaplibreGL(options);
     };
-
-}));
+  }
+);

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -1,413 +1,359 @@
 (function (root, factory) {
-  if (typeof define === "function" && define.amd) {
-    // AMD
-    define(["leaflet", "maplibre-gl"], factory);
-  } else if (typeof exports === "object") {
-    // Node, CommonJS-like
-    module.exports = factory(require("leaflet"), require("maplibre-gl"));
-  } else {
-    // Browser globals (root is window)
-    root.returnExports = factory(root.L, root.maplibregl);
-  }
-})(
-  typeof globalThis !== "undefined" ? globalThis : this || self,
-  function (L, maplibregl) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD
+        define(['leaflet', 'maplibre-gl'], factory);
+    } else if (typeof exports === 'object') {
+        // Node, CommonJS-like
+        module.exports = factory(require('leaflet'), require('maplibre-gl'));
+    } else {
+        // Browser globals (root is window)
+        root.returnExports = factory(root.L, root.maplibregl);
+    }
+}(typeof globalThis !== 'undefined' ? globalThis : this || self, function (L, maplibregl) {
     L.MaplibreGL = L.Layer.extend({
-      options: {
-        updateInterval: 32,
-        // How much to extend the overlay view (relative to map size)
-        // e.g. 0.1 would be 10% of map view in each direction
-        padding: 0.1,
-        // whether or not to register the mouse and keyboard
-        // events on the maplibre overlay
-        interactive: false,
-        // set the tilepane as the default pane to draw gl tiles
-        pane: "tilePane",
-      },
+        options: {
+            updateInterval: 32,
+            // How much to extend the overlay view (relative to map size)
+            // e.g. 0.1 would be 10% of map view in each direction
+            padding: 0.1,
+            // whether or not to register the mouse and keyboard
+            // events on the maplibre overlay
+            interactive: false,
+            // set the tilepane as the default pane to draw gl tiles
+            pane: 'tilePane'
+        },
 
-      initialize: function (options) {
-        L.setOptions(this, options);
+        initialize: function (options) {
+            L.setOptions(this, options);
 
-        // setup throttling the update event when panning
-        this._throttledUpdate = L.Util.throttle(
-          this._update,
-          this.options.updateInterval,
-          this
-        );
-      },
+            // setup throttling the update event when panning
+            this._throttledUpdate = L.Util.throttle(this._update, this.options.updateInterval, this);
+        },
 
-      onAdd: function (map) {
-        if (!this._container) {
-          this._initContainer();
+        onAdd: function (map) {
+            if (!this._container) {
+                this._initContainer();
+            }
+
+            var paneName = this.getPaneName();
+            map.getPane(paneName).appendChild(this._container);
+
+            this._initGL();
+
+            this._offset = this._map.containerPointToLayerPoint([0, 0]);
+
+            // work around https://github.com/mapbox/mapbox-gl-leaflet/issues/47
+            if (map.options.zoomAnimation) {
+                L.DomEvent.on(map._proxy, L.DomUtil.TRANSITION_END, this._transitionEnd, this);
+            }
+        },
+
+        onRemove: function (map) {
+            if (this._map._proxy && this._map.options.zoomAnimation) {
+                L.DomEvent.off(this._map._proxy, L.DomUtil.TRANSITION_END, this._transitionEnd, this);
+            }
+            var paneName = this.getPaneName();
+            map.getPane(paneName).removeChild(this._container);
+
+            this._glMap.remove();
+            this._glMap = null;
+        },
+
+        getEvents: function () {
+            return {
+                move: this._throttledUpdate, // sensibly throttle updating while panning
+                zoomanim: this._animateZoom, // applys the zoom animation to the <canvas>
+                zoom: this._pinchZoom, // animate every zoom event for smoother pinch-zooming
+                zoomstart: this._zoomStart, // flag starting a zoom to disable panning
+                zoomend: this._zoomEnd,
+                resize: this._resize
+            };
+        },
+
+        // https://leafletjs.com/reference.html#layer-getattribution
+        getAttribution: function () {
+            // Return custom attribution if specified in options
+            if (this.options.attributionControl) {
+                return this.options.attributionControl.customAttribution;
+            }
+
+            // Gather attributions from MapLibre styles
+            var map = this._glMap;
+            if (map && this.options.attributionControl !== false) {
+                var style = map.getStyle();
+                if (style && style.sources) {
+                    return Object.keys(style.sources)
+                        .map(function (sourceId) {
+                            var source = map.getSource(sourceId);
+                            return (source && typeof source.attribution === 'string') ? source.attribution.trim() : null;
+                        })
+                        .filter(Boolean) // Remove null/undefined values
+                        .join(', ');
+                }
+            }
+
+            return '';
+        },
+
+        getMaplibreMap: function () {
+            return this._glMap;
+        },
+
+        getCanvas: function () {
+            return this._glMap.getCanvas();
+        },
+
+        getSize: function () {
+            return this._map.getSize().multiplyBy(1 + this.options.padding * 2);
+        },
+
+        getBounds: function () {
+            var halfSize = this.getSize().multiplyBy(0.5);
+            var center = this._map.latLngToContainerPoint(this._map.getCenter());
+            return L.latLngBounds(
+                this._map.containerPointToLatLng(center.subtract(halfSize)),
+                this._map.containerPointToLatLng(center.add(halfSize))
+            );
+        },
+
+        getContainer: function () {
+            return this._container;
+        },
+
+        // returns the pane name set in options if it is a valid pane, defaults to tilePane
+        getPaneName: function () {
+            return this._map.getPane(this.options.pane) ? this.options.pane : 'tilePane';
+        },
+
+        _roundPoint: function (p) {
+            return {x: Math.round(p.x), y: Math.round(p.y)};
+        },
+
+        _initContainer: function () {
+            var container = this._container = L.DomUtil.create('div', 'leaflet-gl-layer');
+            this._resizeContainer();
+
+            var offset = this._map.getSize().multiplyBy(this.options.padding);
+
+            var topLeft = this._map.containerPointToLayerPoint([0, 0]).subtract(offset);
+
+            L.DomUtil.setPosition(container, this._roundPoint(topLeft));
+        },
+
+        _resizeContainer: function () {
+            var size = this.getSize();
+            this._container.style.width = size.x + 'px';
+            this._container.style.height = size.y + 'px';
+        },
+
+        _initGL: function () {
+            var center = this._map.getCenter();
+
+            var options = L.extend({}, this.options, {
+                container: this._container,
+                center: [center.lng, center.lat],
+                zoom: this._map.getZoom() - 1,
+                attributionControl: false
+            });
+
+            this._glMap = new maplibregl.Map(options);
+
+            var _map = this._map;
+            var _getAttribution = this.getAttribution.bind(this);
+            this._glMap.on('load', function () {
+                // Force attribution update
+                if (_map && _map.attributionControl) {
+                    _map.attributionControl.addAttribution(_getAttribution());
+                }
+            });
+
+            // once the map renders for the first time, we update the map
+            // this is necessary to ensure the map is rendered correctly
+            // when the map starts zoomed out beyond the min/max latitudes
+            this._glMap.once("render", () => {
+                this._update();
+                this._glMap.triggerRepaint();
+                canvas.style.opacity = 1;
+            });
+
+            // allow GL base map to pan beyond min/max latitudes
+            // Defensively check if properties are writable before setting them,
+            // ensuring compatibility with both old and new versions of MapLibre GL JS.
+            var transformProto = Object.getPrototypeOf(this._glMap.transform);
+
+            var latRangeDescriptor = Object.getOwnPropertyDescriptor(transformProto, 'latRange');
+            if (!latRangeDescriptor || latRangeDescriptor.set || latRangeDescriptor.writable) {
+                this._glMap.transform.latRange = null;
+            }
+
+            // Although this property is obsolete in modern versions, we apply the same
+            // defensive check for robust backward compatibility.
+            var maxValidLatitudeDescriptor = Object.getOwnPropertyDescriptor(transformProto, 'maxValidLatitude');
+            if (!maxValidLatitudeDescriptor || maxValidLatitudeDescriptor.set || maxValidLatitudeDescriptor.writable) {
+                this._glMap.transform.maxValidLatitude = Infinity;
+            }
+
+
+            // check for the existence of _helper and _latRange in MapLibre
+            // this supports MapLibre v5
+            if (this._glMap.transform._helper && this._glMap.transform._helper._latRange) {
+                this._glMap.transform._helper._latRange = [-Infinity, Infinity];
+            }
+
+            this._transformGL(this._glMap);
+
+            if (this._glMap._canvas.canvas) {
+                // older versions of mapbox-gl surfaced the canvas differently
+                this._glMap._actualCanvas = this._glMap._canvas.canvas;
+            } else {
+                this._glMap._actualCanvas = this._glMap._canvas;
+            }
+
+
+            // treat child <canvas> element like L.ImageOverlay
+            var canvas = this._glMap._actualCanvas;
+            L.DomUtil.addClass(canvas, 'leaflet-image-layer');
+            L.DomUtil.addClass(canvas, 'leaflet-zoom-animated');
+
+            // hide the map until it is loaded, to prevent flickering
+            // this is a workaround for when the map is zoomed out beyond the
+            // min/max latitudes, which causes the map to flicker until it is interacted with
+            // after the map renders for the frist time, we set the opacity to 1
+            canvas.style.opacity = 0;
+
+            if (this.options.interactive) {
+                L.DomUtil.addClass(canvas, 'leaflet-interactive');
+            }
+            if (this.options.className) {
+                L.DomUtil.addClass(canvas, this.options.className);
+            }
+        },
+
+        _update: function (e) {
+            if (!this._map) {
+                return;
+            }
+            // update the offset so we can correct for it later when we zoom
+            this._offset = this._map.containerPointToLayerPoint([0, 0]);
+
+            if (this._zooming) {
+                return;
+            }
+
+            var container = this._container,
+                gl = this._glMap,
+                offset = this._map.getSize().multiplyBy(this.options.padding),
+                topLeft = this._map.containerPointToLayerPoint([0, 0]).subtract(offset);
+
+            L.DomUtil.setPosition(container, this._roundPoint(topLeft));
+
+            this._transformGL(gl);
+        },
+
+        _transformGL: function (gl) {
+            var center = this._map.getCenter();
+
+            // gl.setView([center.lat, center.lng], this._map.getZoom() - 1, 0);
+            // calling setView directly causes sync issues because it uses requestAnimFrame
+
+            var tr = gl._getTransformForUpdate(); // .clone() ?
+
+            if (tr.setCenter) {
+                // maplibre 5.0.0 and higher:
+                tr.setCenter(maplibregl.LngLat.convert([center.lng, center.lat]));
+                tr.setZoom(this._map.getZoom() - 1);
+                gl.transform.apply(tr);
+            } else {
+                // maplibre < 5.0.0
+                tr = gl.transform;
+                tr.center = maplibregl.LngLat.convert([center.lng, center.lat]);
+                tr.zoom = this._map.getZoom() - 1;
+            }
+
+            gl._fireMoveEvents();
+        },
+
+        // update the map constantly during a pinch zoom
+        _pinchZoom: function (e) {
+            this._glMap.jumpTo({
+                zoom: this._map.getZoom() - 1,
+                center: this._map.getCenter()
+            });
+        },
+
+        // borrowed from L.ImageOverlay
+        // https://github.com/Leaflet/Leaflet/blob/master/src/layer/ImageOverlay.js#L139-L144
+        _animateZoom: function (e) {
+            var scale = this._map.getZoomScale(e.zoom);
+            var padding = this._map.getSize().multiplyBy(this.options.padding * scale);
+            var viewHalf = this.getSize()._divideBy(2);
+            // corrections for padding (scaled), adapted from
+            // https://github.com/Leaflet/Leaflet/blob/master/src/map/Map.js#L1490-L1508
+            var topLeft = this._map.project(e.center, e.zoom)
+                ._subtract(viewHalf)
+                ._add(this._map._getMapPanePos()
+                    .add(padding))._round();
+            var offset = this._map.project(this._map.getBounds().getNorthWest(), e.zoom)
+                ._subtract(topLeft);
+
+            L.DomUtil.setTransform(
+                this._glMap._actualCanvas,
+                offset.subtract(this._offset),
+                scale
+            );
+        },
+
+        _zoomStart: function (e) {
+            this._zooming = true;
+        },
+
+        _zoomEnd: function () {
+            var scale = this._map.getZoomScale(this._map.getZoom());
+
+            L.DomUtil.setTransform(
+                this._glMap._actualCanvas,
+                // https://github.com/mapbox/mapbox-gl-leaflet/pull/130
+                null,
+                scale
+            );
+
+            this._zooming = false;
+
+            this._update();
+        },
+
+        _transitionEnd: function (e) {
+            L.Util.requestAnimFrame(function () {
+                var zoom = this._map.getZoom();
+                var center = this._map.getCenter();
+                var offset = this._map.latLngToContainerPoint(
+                    this._map.getBounds().getNorthWest()
+                );
+                this._resizeContainer();
+
+                // reset the scale and offset
+                L.DomUtil.setTransform(this._glMap._actualCanvas, offset, 1);
+
+                // enable panning once the gl map is ready again
+                this._glMap.once('moveend', L.Util.bind(function () {
+                    this._zoomEnd();
+                }, this));
+
+                // update the map position
+                this._glMap.jumpTo({
+                    center: center,
+                    zoom: zoom - 1
+                });
+            }, this);
+        },
+
+        _resize: function (e) {
+            this._transitionEnd(e);
         }
-
-        var paneName = this.getPaneName();
-        map.getPane(paneName).appendChild(this._container);
-
-        this._initGL();
-
-        this._offset = this._map.containerPointToLayerPoint([0, 0]);
-
-        // work around https://github.com/mapbox/mapbox-gl-leaflet/issues/47
-        if (map.options.zoomAnimation) {
-          L.DomEvent.on(
-            map._proxy,
-            L.DomUtil.TRANSITION_END,
-            this._transitionEnd,
-            this
-          );
-        }
-      },
-
-      onRemove: function (map) {
-        if (this._map._proxy && this._map.options.zoomAnimation) {
-          L.DomEvent.off(
-            this._map._proxy,
-            L.DomUtil.TRANSITION_END,
-            this._transitionEnd,
-            this
-          );
-        }
-        var paneName = this.getPaneName();
-        map.getPane(paneName).removeChild(this._container);
-
-        this._glMap.remove();
-        this._glMap = null;
-      },
-
-      getEvents: function () {
-        return {
-          move: this._throttledUpdate, // sensibly throttle updating while panning
-          zoomanim: this._animateZoom, // applys the zoom animation to the <canvas>
-          zoom: this._pinchZoom, // animate every zoom event for smoother pinch-zooming
-          zoomstart: this._zoomStart, // flag starting a zoom to disable panning
-          zoomend: this._zoomEnd,
-          resize: this._resize,
-        };
-      },
-
-      // https://leafletjs.com/reference.html#layer-getattribution
-      getAttribution: function () {
-        // Return custom attribution if specified in options
-        if (this.options.attributionControl) {
-          return this.options.attributionControl.customAttribution;
-        }
-
-        // Gather attributions from MapLibre styles
-        var map = this._glMap;
-        if (map && this.options.attributionControl !== false) {
-          var style = map.getStyle();
-          if (style && style.sources) {
-            return Object.keys(style.sources)
-              .map(function (sourceId) {
-                var source = map.getSource(sourceId);
-                return source && typeof source.attribution === "string"
-                  ? source.attribution.trim()
-                  : null;
-              })
-              .filter(Boolean) // Remove null/undefined values
-              .join(", ");
-          }
-        }
-
-        return "";
-      },
-
-      getMaplibreMap: function () {
-        return this._glMap;
-      },
-
-      getCanvas: function () {
-        return this._glMap.getCanvas();
-      },
-
-      getSize: function () {
-        return this._map.getSize().multiplyBy(1 + this.options.padding * 2);
-      },
-
-      getBounds: function () {
-        var halfSize = this.getSize().multiplyBy(0.5);
-        var center = this._map.latLngToContainerPoint(this._map.getCenter());
-        return L.latLngBounds(
-          this._map.containerPointToLatLng(center.subtract(halfSize)),
-          this._map.containerPointToLatLng(center.add(halfSize))
-        );
-      },
-
-      getContainer: function () {
-        return this._container;
-      },
-
-      // returns the pane name set in options if it is a valid pane, defaults to tilePane
-      getPaneName: function () {
-        return this._map.getPane(this.options.pane)
-          ? this.options.pane
-          : "tilePane";
-      },
-
-      _roundPoint: function (p) {
-        return { x: Math.round(p.x), y: Math.round(p.y) };
-      },
-
-      _initContainer: function () {
-        var container = (this._container = L.DomUtil.create(
-          "div",
-          "leaflet-gl-layer"
-        ));
-        this._resizeContainer();
-
-        var offset = this._map.getSize().multiplyBy(this.options.padding);
-
-        var topLeft = this._map
-          .containerPointToLayerPoint([0, 0])
-          .subtract(offset);
-
-        L.DomUtil.setPosition(container, this._roundPoint(topLeft));
-      },
-
-      _resizeContainer: function () {
-        var size = this.getSize();
-        this._container.style.width = size.x + "px";
-        this._container.style.height = size.y + "px";
-      },
-
-      _initGL: function () {
-        var center = this._map.getCenter();
-
-        var options = L.extend({}, this.options, {
-          container: this._container,
-          center: [center.lng, center.lat],
-          zoom: this._map.getZoom() - 1,
-          attributionControl: false,
-        });
-
-        this._glMap = new maplibregl.Map(options);
-
-        var _map = this._map;
-        var _getAttribution = this.getAttribution.bind(this);
-
-        this._glMap.on("load", () => {
-          // Force attribution update
-          if (_map && _map.attributionControl) {
-            _map.attributionControl.addAttribution(_getAttribution());
-          }
-        });
-
-        // once the map renders for the first time, we update the map
-        // this is necessary to ensure the map is rendered correctly
-        // and to prevent flickering when the map is zoomed out beyond the min/max latitudes
-        this._glMap.once("render", () => {
-          this._update();
-          this._glMap.triggerRepaint();
-          canvas.style.opacity = 1;
-        });
-
-        // allow GL base map to pan beyond min/max latitudes
-        // Defensively check if properties are writable before setting them,
-        // ensuring compatibility with both old and new versions of MapLibre GL JS.
-        // This supports MapLibre v3
-        const transformProto = Object.getPrototypeOf(this._glMap.transform);
-
-        const latRangeDescriptor = Object.getOwnPropertyDescriptor(
-          transformProto,
-          "latRange"
-        );
-        if (
-          !latRangeDescriptor ||
-          latRangeDescriptor.set ||
-          latRangeDescriptor.writable
-        ) {
-          this._glMap.transform.latRange = null;
-        }
-
-        // Although this property is obsolete in modern versions, we apply the same
-        // defensive check for robust backward compatibility.
-        // This supports MapLibre v4
-        const maxValidLatitudeDescriptor = Object.getOwnPropertyDescriptor(
-          transformProto,
-          "maxValidLatitude"
-        );
-        if (
-          !maxValidLatitudeDescriptor ||
-          maxValidLatitudeDescriptor.set ||
-          maxValidLatitudeDescriptor.writable
-        ) {
-          this._glMap.transform.maxValidLatitude = Infinity;
-        }
-
-        // check for the existence of _helper and _latRange in MapLibre
-        // this supports MapLibre v5
-        if (
-          this._glMap.transform._helper &&
-          this._glMap.transform._helper._latRange
-        ) {
-          this._glMap.transform._helper._latRange = [-Infinity, Infinity];
-        }
-
-        this._update();
-
-        if (this._glMap._canvas.canvas) {
-          // older versions of mapbox-gl surfaced the canvas differently
-          this._glMap._actualCanvas = this._glMap._canvas.canvas;
-        } else {
-          this._glMap._actualCanvas = this._glMap._canvas;
-        }
-
-        // treat child <canvas> element like L.ImageOverlay
-        var canvas = this._glMap._actualCanvas;
-        L.DomUtil.addClass(canvas, "leaflet-image-layer");
-        L.DomUtil.addClass(canvas, "leaflet-zoom-animated");
-
-        // hide the map until it is loaded, to prevent flickering
-        // this is a workaround for when the map is zoomed out beyond the
-        // min/max latitudes, which causes the map to flicker until it is interacted with
-        // after the map renders for the frist time, we set the opacity to 1
-        canvas.style.opacity = 0;
-
-        if (this.options.interactive) {
-          L.DomUtil.addClass(canvas, "leaflet-interactive");
-        }
-
-        if (this.options.className) {
-          L.DomUtil.addClass(canvas, this.options.className);
-        }
-      },
-
-      _update: function (e) {
-        if (!this._map) {
-          return;
-        }
-
-        // update the offset so we can correct for it later when we zoom
-        this._offset = this._map.containerPointToLayerPoint([0, 0]);
-
-        if (this._zooming) {
-          return;
-        }
-
-        var container = this._container,
-          gl = this._glMap,
-          offset = this._map.getSize().multiplyBy(this.options.padding),
-          topLeft = this._map
-            .containerPointToLayerPoint([0, 0])
-            .subtract(offset);
-
-        L.DomUtil.setPosition(container, this._roundPoint(topLeft));
-
-        this._transformGL(gl);
-      },
-
-      _transformGL: function (gl) {
-        var center = this._map.getCenter();
-
-        // gl.setView([center.lat, center.lng], this._map.getZoom() - 1, 0);
-        // calling setView directly causes sync issues because it uses requestAnimFrame
-
-        var tr = gl._getTransformForUpdate(); // .clone() ?
-
-        if (tr.setCenter) {
-          // maplibre 5.0.0 and higher:
-          tr.setCenter(maplibregl.LngLat.convert([center.lng, center.lat]));
-          tr.setZoom(this._map.getZoom() - 1);
-          gl.transform.apply(tr);
-        } else {
-          // maplibre < 5.0.0
-          tr = gl.transform;
-          tr.center = maplibregl.LngLat.convert([center.lng, center.lat]);
-          tr.zoom = this._map.getZoom() - 1;
-        }
-
-        gl._fireMoveEvents();
-      },
-
-      // update the map constantly during a pinch zoom
-      _pinchZoom: function (e) {
-        this._glMap.jumpTo({
-          zoom: this._map.getZoom() - 1,
-          center: this._map.getCenter(),
-        });
-      },
-
-      // borrowed from L.ImageOverlay
-      // https://github.com/Leaflet/Leaflet/blob/master/src/layer/ImageOverlay.js#L139-L144
-      _animateZoom: function (e) {
-        var scale = this._map.getZoomScale(e.zoom);
-        var padding = this._map
-          .getSize()
-          .multiplyBy(this.options.padding * scale);
-        var viewHalf = this.getSize()._divideBy(2);
-        // corrections for padding (scaled), adapted from
-        // https://github.com/Leaflet/Leaflet/blob/master/src/map/Map.js#L1490-L1508
-        var topLeft = this._map
-          .project(e.center, e.zoom)
-          ._subtract(viewHalf)
-          ._add(this._map._getMapPanePos().add(padding))
-          ._round();
-        var offset = this._map
-          .project(this._map.getBounds().getNorthWest(), e.zoom)
-          ._subtract(topLeft);
-
-        L.DomUtil.setTransform(
-          this._glMap._actualCanvas,
-          offset.subtract(this._offset),
-          scale
-        );
-      },
-
-      _zoomStart: function (e) {
-        this._zooming = true;
-      },
-
-      _zoomEnd: function () {
-        var scale = this._map.getZoomScale(this._map.getZoom());
-
-        L.DomUtil.setTransform(
-          this._glMap._actualCanvas,
-          // https://github.com/mapbox/mapbox-gl-leaflet/pull/130
-          null,
-          scale
-        );
-
-        this._zooming = false;
-
-        this._update();
-      },
-
-      _transitionEnd: function (e) {
-        L.Util.requestAnimFrame(function () {
-          var zoom = this._map.getZoom();
-          var center = this._map.getCenter();
-          var offset = this._map.latLngToContainerPoint(
-            this._map.getBounds().getNorthWest()
-          );
-          this._resizeContainer();
-
-          // reset the scale and offset
-          L.DomUtil.setTransform(this._glMap._actualCanvas, offset, 1);
-
-          // enable panning once the gl map is ready again
-          this._glMap.once(
-            "moveend",
-            L.Util.bind(function () {
-              this._zoomEnd();
-            }, this)
-          );
-
-          // update the map position
-          this._glMap.jumpTo({
-            center: center,
-            zoom: zoom - 1,
-          });
-        }, this);
-      },
-
-      _resize: function (e) {
-        this._transitionEnd(e);
-      },
     });
 
     L.maplibreGL = function (options) {
-      return new L.MaplibreGL(options);
+        return new L.MaplibreGL(options);
     };
-  }
-);
+
+}));

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -218,7 +218,7 @@
             // hide the map until it is loaded, to prevent flickering
             // this is a workaround for when the map is zoomed out beyond the
             // min/max latitudes, which causes the map to flicker until it is interacted with
-            // after the map renders for the frist time, we set the opacity to 1
+            // after the map renders for the first time, we set the opacity to 1
             canvas.style.opacity = 0;
 
             if (this.options.interactive) {


### PR DESCRIPTION
This is my attempt to finally solve #72 and #73. The relevant changes are:

* Overriding the min/max latitudes for MapLibre v5. This does involve another private API but is likely the best option at this point to get the rendering synced.
* Re-rendering after the first MapLibre render to sync up the rendering with with Leaflet. This resolves an issue where the initial render of Maplibre and Leaflet are out of sync if you are zoomed out far enough to be beyond the 85 degree max latitude of MapLibre. Re-rendering seemed to fix this.
* The readme and basic examples updated to recommend the use of `maxBounds` when using this plug-in for the best experience.