### PR TITLE
fix: handle attribution update on map style change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-### Added
+### Fixed
 
-- Add attribution handling to the Leaflet layer based on the `attributionControl` option and the source's `attribution` property
+- Fix attribution not updating when MapLibre styles or sources change
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ var gl = L.maplibreGL({
 }).addTo(map);
 ```
 
+When switching MapLibre styles, the plugin automatically synchronizes the active style's source attributions with Leaflet's attribution control.
+
 Once you have created the leaflet layer, the maplibre-gl map object can be accessed using
 
 ```javascript

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -77,18 +77,23 @@
                 return this.options.attributionControl.customAttribution;
             }
 
-            // Gather attributions from MapLibre styles
+            // Gather attributions from MapLibre style sources
             var map = this._glMap;
             if (map && this.options.attributionControl !== false) {
                 var style = map.getStyle();
+
                 if (style && style.sources) {
-                    return Object.keys(style.sources)
+                    var attributions = Object.keys(style.sources)
                         .map(function (sourceId) {
-                            var source = map.getSource(sourceId);
-                            return (source && typeof source.attribution === 'string') ? source.attribution.trim() : null;
+                            var styleSource = style.sources[sourceId];
+                            if (styleSource && typeof styleSource.attribution === 'string') {
+                                return styleSource.attribution.trim();
+                            }
+                            return null;
                         })
-                        .filter(Boolean) // Remove null/undefined values
-                        .join(', ');
+                        .filter(Boolean); // Remove null/undefined values
+
+                    return attributions.join(', ');
                 }
             }
 
@@ -159,15 +164,28 @@
             this._glMap = new maplibregl.Map(options);
 
             var _map = this._map;
-            var _currentAttribution = this.getAttribution();
             var _getAttribution = this.getAttribution.bind(this);
-            this._glMap.on('load', function () {
-                // Force attribution update
+            var _currentAttribution = null;
+
+            var _updateAttribution = function () {
                 if (_map && _map.attributionControl) {
-                    _map.attributionControl.removeAttribution(_currentAttribution);
-                    _map.attributionControl.addAttribution(_getAttribution());
+                    var newAttr = _getAttribution();
+
+                    if (newAttr !== _currentAttribution) {
+                        if (_currentAttribution) {
+                            _map.attributionControl.removeAttribution(_currentAttribution);
+                        }
+                        if (newAttr) {
+                            _map.attributionControl.addAttribution(newAttr);
+                        }
+                        _currentAttribution = newAttr;
+                    }
                 }
-            });
+            };
+
+            // Listen to styledata event - this fires when style changes
+            // including when switching between different styles
+            this._glMap.on('styledata', _updateAttribution);
 
             // allow GL base map to pan beyond min/max latitudes
             // Defensively check if properties are writable before setting them,


### PR DESCRIPTION
This pull request addresses a bug where Leaflet attribution was not updating correctly when MapLibre styles or sources changed. The main fix ensures the plugin now synchronizes source attributions with Leaflet's attribution control whenever the MapLibre style changes, improving attribution accuracy and user experience.

**Bug fix: Attribution synchronization**
* Fixed attribution not updating when MapLibre styles or sources change, ensuring Leaflet's attribution control always reflects the current style's sources.

**Attribution handling logic**
* Modified attribution gathering to use attributions directly from the MapLibre style's sources, rather than from the instantiated source objects. This ensures more reliable attribution extraction.
* Refactored attribution update mechanism to listen for the `styledata` event, so attribution is updated whenever the style changes, and only updates when the attribution actually changes.

**Testing**
The change was exercised in the Next.js test repository [fityannugroho/maplibre-gl-leaflet-test](https://github.com/fityannugroho/maplibre-gl-leaflet-test). The test app mounts the leaflet-maplibre-gl layer inside a Next.js page and runs the scenarios to confirm that Leaflet's attribution control always reflects the active MapLibre style's source attributions, avoids duplicates, and removes old attributions when the style or source attribution changes.

**Related Issues/PR**
- Will (actually) fix #83 
- Improve #61 