### PR TITLE
ci: Use npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     name: Publish
@@ -26,6 +30,4 @@ jobs:
 
       - name: Publish
         run: |
-          npm publish --access=public --non-interactive
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
+          npm publish --access=public


### PR DESCRIPTION
Use npm trusted publisher for release authentication instead of the stale NPM_ORG_TOKEN